### PR TITLE
Update assertion in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ api_response = resp.json()
 # {'username': 'emmag', 'userId': 1312, 'somethingElse': ['irrelevant']}
 
 user = User.from_json(api_response)
-assert user.username = 'emmag'
+assert user.username == 'emmag'
 assert isinstance(user.user_id, int)
 assert user.birthday is None
 ```


### PR DESCRIPTION
In the README, there is a typo in the assertion for the example. This change updates the assertion to use a double equals (`==`) for comparison, rather than a single equals (`=`) for assignment